### PR TITLE
Use SPDX ID for license

### DIFF
--- a/rubygems-bundler.gemspec
+++ b/rubygems-bundler.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://mpapis.github.com/rubygems-bundler"
   s.summary     = %q{Stop using bundle exec}
   s.description = %q{Stop using bundle exec. Integrate Rubygems and Bundler. Make rubygems generate bundler aware executable wrappers.}
-  s.license     = 'Apache 2.0'
+  s.license     = 'Apache-2.0'
 
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Is follow-up to https://github.com/mpapis/rubygems-bundler/commit/321583bb5904a5036fcb526359b66525dc55071d

ref: https://spdx.org/licenses/
