### PR TITLE
README: Drop defunct service gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://secure.travis-ci.org/mpapis/rubygems-bundler.png?branch=1.0.0)](http://travis-ci.org/mpapis/rubygems-bundler)
-[![Dependency Status](https://gemnasium.com/mpapis/rubygems-bundler.png)](https://gemnasium.com/mpapis/rubygems-bundler)
 
 # Note for RubyGems >= 2.2.0
 


### PR DESCRIPTION
Dropping the Gemnasium badge: that service is closed.